### PR TITLE
rename docker hub repo

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -54,7 +54,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: backplane/open-webui-mirror
+          images: backplane/open-webui
           flavor: |
             latest=false
             suffix=${{ matrix.variant }}
@@ -97,4 +97,4 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-          repository: ${{ github.repository }}
+          repository: backplane/open-webui

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
-# open-webui-mirror
+# open-webui mirror
 
 Repo                                | URL
 ----------------------------------- | --------------------------------------------------------------------
-`open-webui-mirror` Docker Hub Repo | <https://hub.docker.com/r/backplane/open-webui-mirror>
-`open-webui-mirror` GitHub Repo     | <https://github.com/backplane/open-webui-mirror/>
 `open-webui` GitHub Repo            | <https://github.com/open-webui/open-webui>
 `open-webui` GHCR Repo              | <https://github.com/open-webui/open-webui/pkgs/container/open-webui>
+`open-webui` Docker Hub Repo        | <https://hub.docker.com/r/backplane/open-webui>
+`open-webui-mirror` GitHub Repo     | <https://github.com/backplane/open-webui-mirror/>
 
 This repo mirrors the Docker images published on the [open-webui project](https://github.com/open-webui/open-webui)'s GitHub Container Registry [repo](https://github.com/open-webui/open-webui/pkgs/container/open-webui) onto Docker Hub.
-
 
 ## Notes
 
@@ -17,30 +16,30 @@ This repo mirrors the Docker images published on the [open-webui project](https:
 * When a semver tag is mirrored from upstream, we create separate "major", "minor", and "patch" -level docker tags from it.
 * All three variants are mirrored: `main` (no suffix), `ollama`, and `cuda`
 * Both the `linux/arm64` and `linux/amd64` architectures are mirrored for each variant.
-* The list of mirrored image tags can be found here: <https://hub.docker.com/r/backplane/open-webui-mirror/tags>
+* The list of mirrored image tags can be found here: <https://hub.docker.com/r/backplane/open-webui/tags>
 
 ## Examples
 
 ### pulling a major version tag
 
 ```
-docker pull backplane/open-webui-mirror:0
-docker pull backplane/open-webui-mirror:0-cuda
-docker pull backplane/open-webui-mirror:0-ollama
+docker pull backplane/open-webui:0
+docker pull backplane/open-webui:0-cuda
+docker pull backplane/open-webui:0-ollama
 ```
 
 ### pulling a minor version tag
 
 ```
-docker pull backplane/open-webui-mirror:0.1
-docker pull backplane/open-webui-mirror:0.1-cuda
-docker pull backplane/open-webui-mirror:0.1-ollama
+docker pull backplane/open-webui:0.1
+docker pull backplane/open-webui:0.1-cuda
+docker pull backplane/open-webui:0.1-ollama
 ```
 
 ### pulling a specific patch version
 
 ```
-docker pull backplane/open-webui-mirror:0.1.123
-docker pull backplane/open-webui-mirror:0.1.123-cuda
-docker pull backplane/open-webui-mirror:0.1.123-ollama
+docker pull backplane/open-webui:0.1.123
+docker pull backplane/open-webui:0.1.123-cuda
+docker pull backplane/open-webui:0.1.123-ollama
 ```


### PR DESCRIPTION
renames docker hub repo from `backplane/open-webui-mirror` to `backplane/open-webui`